### PR TITLE
Allow custom mode area and overlaps

### DIFF
--- a/examples/waveguide_simulation.py
+++ b/examples/waveguide_simulation.py
@@ -1,0 +1,38 @@
+"""Waveguide simulation example using custom mode area and overlaps.
+
+This script demonstrates how to simulate amplification in an integrated
+waveguide without relying on a mode solver.  The effective mode area and
+modal overlaps are supplied directly by the user.
+"""
+
+from pathlib import Path
+import sys
+import numpy as np
+
+# Allow running the example without installing the package
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from pyfiberamp.fibers.yb_doped_fiber import YbDopedFiber
+from pyfiberamp.steady_state import SteadyStateSimulation
+
+
+# Effective mode area of the waveguide (m^2). For a rectangular
+# 4.5 µm x 4.5 µm waveguide this is roughly 20e-12 m^2.
+MODE_AREA = 20e-12
+ION_DENSITY = 1e25  # 1/m^3
+
+# Create a Yb-doped waveguide using the supplied mode area.
+fiber = YbDopedFiber(length=0.02, ion_number_density=ION_DENSITY,
+                     mode_area=MODE_AREA)
+
+# Set up a simple forward‑pumped amplifier: a pump at 980 nm and a
+# small signal at 1030 nm.  The modal overlaps with the doped region are
+# specified directly and no mode solver is needed.
+sim = SteadyStateSimulation(fiber)
+sim.add_forward_pump(wl=980e-9, input_power=5.0, overlap=0.9)
+sim.add_forward_signal(wl=1030e-9, input_power=1e-3, overlap=0.85)
+
+# Run the simulation and print the output powers.
+result = sim.run()
+for cid, ch in result.make_result_dict().items():
+    print(f"{cid}: output {ch['output_power']:.3f} W, gain {ch['gain']:.2f} dB")

--- a/pyfiberamp/channels.py
+++ b/pyfiberamp/channels.py
@@ -33,23 +33,31 @@ class Channels:
         return channel_id
 
     def create_channel(self, channel_type, direction,
-                       fiber, input_power, wl, mode, channel_id=None,
+                       fiber, input_power, wl, mode=None, overlaps=None, channel_id=None,
                        num_of_modes=NUMBER_OF_ASE_POLARIZATION_MODES, wl_bandwidth=0.0,
                        loss=None,
                        reflection_target_id=None, reflectance=0.0,
                        peak_power_func=lambda x: x):
-        if mode is None:
-            if channel_type in ['signal', 'ase', 'raman']:
-                mode = fiber.default_signal_mode(wl_to_freq(wl))
-            else:
-                mode = fiber.default_pump_mode(wl_to_freq(wl))
+        if overlaps is None:
+            if mode is None:
+                if channel_type in ['signal', 'ase', 'raman']:
+                    mode = fiber.default_signal_mode(wl_to_freq(wl))
+                else:
+                    mode = fiber.default_pump_mode(wl_to_freq(wl))
 
-        channel = OpticalChannel.from_mode(channel_id, channel_type, direction,
-                                           fiber, input_power, wl, mode,
-                                           num_of_modes, wl_bandwidth,
-                                           loss,
-                                           reflection_target_id, reflectance,
-                                           peak_power_func)
+            channel = OpticalChannel.from_mode(channel_id, channel_type, direction,
+                                               fiber, input_power, wl, mode,
+                                               num_of_modes, wl_bandwidth,
+                                               loss,
+                                               reflection_target_id, reflectance,
+                                               peak_power_func)
+        else:
+            channel = OpticalChannel.from_overlaps(channel_id, channel_type, direction,
+                                                   fiber, input_power, wl, overlaps,
+                                                   num_of_modes, wl_bandwidth,
+                                                   loss,
+                                                   reflection_target_id, reflectance,
+                                                   peak_power_func, mode=mode)
         self.add_channel(channel)
 
     def add_channel(self, channel):

--- a/pyfiberamp/dynamic/dynamic_simulation.py
+++ b/pyfiberamp/dynamic/dynamic_simulation.py
@@ -121,8 +121,8 @@ class DynamicSimulation:
                                                                       'should be below the upper state life time.'
         return np.linspace(0, self.max_time_steps, self.max_time_steps, endpoint=False) * dt
 
-    def add_forward_signal(self, wl: float, input_power, wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
-                           reflection_target_id=None, reflectance=0.0):
+    def add_forward_signal(self, wl: float, input_power, wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
+                            reflection_target_id=None, reflectance=0.0):
         """Adds a new forward propagating single-frequency CW signal to the simulation.
 
         :param wl: Wavelength of the signal
@@ -144,12 +144,14 @@ class DynamicSimulation:
         :type reflectance: float
 
         """
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='signal',
                                      direction=1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,
@@ -157,7 +159,7 @@ class DynamicSimulation:
                                      reflectance=reflectance)
 
     def add_backward_signal(self, wl: float, input_power, wl_bandwidth=0.0, loss=None,
-                            mode=None, channel_id=None,
+                            mode=None, overlap=None, channel_id=None,
                             reflection_target_id=None, reflectance=0.0):
         """Adds a new forward propagating single-frequency CW signal to the simulation.
 
@@ -179,19 +181,21 @@ class DynamicSimulation:
         :type reflectance: float
 
         """
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='signal',
                                      direction=-1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,
                                      reflection_target_id=reflection_target_id,
                                      reflectance=reflectance)
 
-    def add_forward_pump(self, wl:float, input_power, wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
+    def add_forward_pump(self, wl:float, input_power, wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
                          reflection_target_id=None, reflectance=0.0):
         """Adds a new forward propagating single-frequency pump to the simulation.
 
@@ -214,19 +218,21 @@ class DynamicSimulation:
         :type reflectance: float
 
         """
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='pump',
                                      direction=1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,
                                      reflection_target_id=reflection_target_id,
                                      reflectance=reflectance)
 
-    def add_backward_pump(self, wl: float, input_power, wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
+    def add_backward_pump(self, wl: float, input_power, wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
                           reflection_target_id=None, reflectance=0.0):
         """Adds a new backward propagating single-frequency pump to the simulation.
 
@@ -250,12 +256,14 @@ class DynamicSimulation:
 
         """
         self._check_input_power(input_power)
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='pump',
                                      direction=-1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,

--- a/pyfiberamp/fibers/active_fiber.py
+++ b/pyfiberamp/fibers/active_fiber.py
@@ -11,7 +11,7 @@ class ActiveFiber(FiberBase):
     @classmethod
     def from_cross_section_files(cls, length, absorption_cs_file=None, emission_cs_file=None,
                      core_radius=0, upper_state_lifetime=0, ion_number_density=0,
-                     background_loss=0, core_na=0):
+                     background_loss=0, core_na=0, mode_area=None):
         """
         :param length: Fiber length
         :type length: float
@@ -31,10 +31,10 @@ class ActiveFiber(FiberBase):
         :type core_na: float
         """
         spectroscopy = Spectroscopy.from_files(absorption_cs_file, emission_cs_file, upper_state_lifetime)
-        return cls(length, core_radius, background_loss, core_na, spectroscopy, ion_number_density)
+        return cls(length, core_radius, background_loss, core_na, spectroscopy, ion_number_density, mode_area)
 
     def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0,
-                 spectroscopy=None, ion_number_density=0):
+                 spectroscopy=None, ion_number_density=0, mode_area=None):
         """
         :param length: Fiber length
         :type length: float
@@ -53,7 +53,8 @@ class ActiveFiber(FiberBase):
         super().__init__(length=length,
                          core_radius=core_radius,
                          background_loss=background_loss,
-                         core_na=core_na)
+                         core_na=core_na,
+                         mode_area=mode_area)
 
         self.spectroscopy = spectroscopy
         self.doping_profile = DopingProfile(ion_number_densities=[ion_number_density], radii=[core_radius],
@@ -79,7 +80,7 @@ class ActiveFiber(FiberBase):
 
     def saturation_parameter(self):
         """Returns the constant saturation parameter zeta defined in the Giles model."""
-        return zeta_from_fiber_parameters(self.core_radius, self.spectroscopy.upper_state_lifetime, self.ion_number_density)
+        return zeta_from_fiber_parameters(self.core_area(), self.spectroscopy.upper_state_lifetime, self.ion_number_density)
 
     def get_channel_emission_cross_section(self, freq, frequency_bandwidth):
         if frequency_bandwidth == 0:

--- a/pyfiberamp/fibers/double_clad_fiber.py
+++ b/pyfiberamp/fibers/double_clad_fiber.py
@@ -10,7 +10,7 @@ class DoubleCladFiber(ActiveFiber):
     @classmethod
     def from_cross_section_files(cls, length=0, absorption_cs_file=None, emission_cs_file=None,
                  core_radius=0, upper_state_lifetime=0, ion_number_density=0,
-                 background_loss=0, core_na=0, ratio_of_core_and_cladding_diameters=0):
+                 background_loss=0, core_na=0, ratio_of_core_and_cladding_diameters=0, mode_area=None):
         """
         :param length: Fiber length
         :type length: float
@@ -35,10 +35,10 @@ class DoubleCladFiber(ActiveFiber):
 
         spectroscopy = Spectroscopy.from_files(absorption_cs_file, emission_cs_file, upper_state_lifetime)
         cls(length, core_radius, background_loss, core_na, spectroscopy, ion_number_density,
-            ratio_of_core_and_cladding_diameters)
+            mode_area, ratio_of_core_and_cladding_diameters)
 
     def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0,
-                 spectroscopy=None, ion_number_density=0, ratio_of_core_and_cladding_diameters=0):
+                 spectroscopy=None, ion_number_density=0, mode_area=None, ratio_of_core_and_cladding_diameters=0):
 
         """
         :param length: Fiber length
@@ -62,7 +62,8 @@ class DoubleCladFiber(ActiveFiber):
                          spectroscopy=spectroscopy,
                          ion_number_density=ion_number_density,
                          background_loss=background_loss,
-                         core_na=core_na)
+                         core_na=core_na,
+                         mode_area=mode_area)
         self.core_to_cladding_ratio = ratio_of_core_and_cladding_diameters
 
     def pump_to_core_overlap(self):

--- a/pyfiberamp/fibers/fiber_base.py
+++ b/pyfiberamp/fibers/fiber_base.py
@@ -11,7 +11,7 @@ class FiberBase(ABC):
     could act as a base class but subclassing ActiveFiber from PassiveFiber feels conceptually wrong."""
 
     @abstractmethod
-    def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0):
+    def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0, mode_area=None):
         """
 
         :param length: Fiber length
@@ -25,11 +25,14 @@ class FiberBase(ABC):
 
         """
         self.length = length
+        if mode_area is not None and core_radius == 0:
+            core_radius = np.sqrt(mode_area / np.pi)
         self.core_radius = core_radius
+        self.mode_area = mode_area
         self.background_loss = background_loss
         self.core_na = core_na
         self.core_refractive_index = DEFAULT_GROUP_INDEX
-        self.effective_area_type = 'mode'
+        self.effective_area_type = 'core' if mode_area is not None else 'mode'
         self.doping_profile = DopingProfile(ion_number_densities=[0], radii=[core_radius],
                                             num_of_angular_sections=1, core_radius=core_radius)
 
@@ -48,12 +51,16 @@ class FiberBase(ABC):
         return len(self.doping_profile.ion_number_densities)
 
     def core_area(self):
-        """Returns the core area of the fiber defined as pi*r**2, where r is the core radius.
+        """Returns the effective mode area of the fiber. If ``mode_area`` was supplied
+        during initialization, that value is returned. Otherwise the core area
+        is computed as :math:`\pi r^2` from the core radius.
 
-        :returns: Core area
+        :returns: Effective mode area
         :rtype: float
 
         """
+        if self.mode_area is not None:
+            return self.mode_area
         return self.core_radius**2 * np.pi
 
     @abstractmethod

--- a/pyfiberamp/fibers/passive_fiber.py
+++ b/pyfiberamp/fibers/passive_fiber.py
@@ -5,7 +5,7 @@ class PassiveFiber(FiberBase):
     """PassiveFiber describes a step-index single-mode fiber with no dopant ions. It extends the FiberBase class by
     stating that there is no emission or absorption by ions. The only possible gain comes of stimulated Raman
     scattering."""
-    def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0):
+    def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0, mode_area=None):
         """
 
         :param length: Fiber length
@@ -22,7 +22,8 @@ class PassiveFiber(FiberBase):
         super().__init__(length=length,
                          core_radius=core_radius,
                          background_loss=background_loss,
-                         core_na=core_na)
+                         core_na=core_na,
+                         mode_area=mode_area)
 
     def saturation_parameter(self):
         """Returns the saturation parameter, zeta in Giles mode. For passive fiber it is enough that the parameter is

--- a/pyfiberamp/fibers/yb_doped_double_clad_fiber.py
+++ b/pyfiberamp/fibers/yb_doped_double_clad_fiber.py
@@ -5,7 +5,7 @@ class YbDopedDoubleCladFiber(DoubleCladFiber):
     """YbDopedDoubleCladFiber is a convenience class for Yb-doped double-clad fiber that uses the default spectroscopic
      data for Yb-ions."""
     def __init__(self, length, core_radius, ion_number_density,
-                 background_loss, core_na, ratio_of_core_and_cladding_diameters):
+                 background_loss, core_na, ratio_of_core_and_cladding_diameters, mode_area=None):
         """
 
         :param length: Fiber length
@@ -28,4 +28,5 @@ class YbDopedDoubleCladFiber(DoubleCladFiber):
                          spectroscopy=YbGermanoSilicate,
                          background_loss=background_loss,
                          core_na=core_na,
+                         mode_area=mode_area,
                          ratio_of_core_and_cladding_diameters=ratio_of_core_and_cladding_diameters)

--- a/pyfiberamp/fibers/yb_doped_fiber.py
+++ b/pyfiberamp/fibers/yb_doped_fiber.py
@@ -6,7 +6,7 @@ class YbDopedFiber(ActiveFiber):
     """YbDopedFiber is a convenience class for Yb-doped single-mode fiber that uses the default spectroscopic data
      for Yb-ions."""
 
-    def __init__(self, length=0, core_radius=0, ion_number_density=0, background_loss=0, core_na=0):
+    def __init__(self, length=0, core_radius=0, ion_number_density=0, background_loss=0, core_na=0, mode_area=None):
         """
 
         :param length: Fiber length
@@ -26,4 +26,5 @@ class YbDopedFiber(ActiveFiber):
                          background_loss=background_loss,
                          core_na=core_na,
                          ion_number_density=ion_number_density,
-                         spectroscopy=YbGermanoSilicate)
+                         spectroscopy=YbGermanoSilicate,
+                         mode_area=mode_area)

--- a/pyfiberamp/helper_funcs.py
+++ b/pyfiberamp/helper_funcs.py
@@ -25,9 +25,10 @@ def load_two_column_file(file_name: str):
     return np.loadtxt(file_name, converters={0: to_float, 1: to_float})
 
 
-def to_float(x: str):
-    x = x.decode()
-    x = x.replace(',', '.')
+def to_float(x):
+    if isinstance(x, bytes):
+        x = x.decode()
+    x = str(x).replace(',', '.')
     return float(x)
 
 
@@ -162,11 +163,12 @@ def fiber_v_parameter(wl: float, r: float, na: float):
     return 2 * np.pi / wl * r * na
 
 
-def zeta_from_fiber_parameters(core_radius: float, upper_state_lifetime: float, ion_number_density: float):
-    """Calculates the Giles mode's saturation parameter zeta.
+def zeta_from_fiber_parameters(core_area: float, upper_state_lifetime: float, ion_number_density: float):
+    """Calculates the Giles model's saturation parameter ``zeta`` using an
+    effective mode area.
 
-    :param core_radius: Core radius of the fiber
-    :type core_radius: float
+    :param core_area: Effective mode area of the guided mode
+    :type core_area: float
     :param upper_state_lifetime: Lifetime of the excited state
     :type upper_state_lifetime: float
     :param ion_number_density: Number density of the dopant ions (1/m^3)
@@ -174,7 +176,7 @@ def zeta_from_fiber_parameters(core_radius: float, upper_state_lifetime: float, 
     :returns: Saturation parameter zeta
     :rtype: float
     """
-    return np.pi * core_radius**2 * ion_number_density / upper_state_lifetime
+    return core_area * ion_number_density / upper_state_lifetime
 
 
 def gaussian_peak_power(average_power: float, f_rep: float, fwhm_duration: float):

--- a/pyfiberamp/steady_state/steady_state_simulation.py
+++ b/pyfiberamp/steady_state/steady_state_simulation.py
@@ -29,7 +29,7 @@ class SteadyStateSimulation:
         self.channels = Channels(fiber)
         self.solver_verbosity = 2
 
-    def add_forward_signal(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
+    def add_forward_signal(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
                            reflection_target_id=None, reflectance=0.0):
         """Adds a new forward propagating single-frequency CW signal to the simulation.
 
@@ -52,12 +52,14 @@ class SteadyStateSimulation:
         :type reflectance: float
 
         """
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='signal',
                                      direction=1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,
@@ -65,7 +67,7 @@ class SteadyStateSimulation:
                                      reflectance=reflectance)
 
     def add_backward_signal(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None,
-                            mode=None, channel_id=None,
+                            mode=None, overlap=None, channel_id=None,
                             reflection_target_id=None, reflectance=0.0):
         """
         Adds a new forward propagating single-frequency CW signal to the simulation.
@@ -89,19 +91,21 @@ class SteadyStateSimulation:
         :type reflectance: float
 
         """
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='signal',
                                      direction=-1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,
                                      reflection_target_id=reflection_target_id,
                                      reflectance=reflectance)
 
-    def add_forward_pump(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
+    def add_forward_pump(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
                          reflection_target_id=None, reflectance=0.0):
         """
         Adds a new forward propagating single-frequency pump to the simulation.
@@ -125,19 +129,21 @@ class SteadyStateSimulation:
         :type reflectance: float
 
         """
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='pump',
                                      direction=1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,
                                      reflection_target_id=reflection_target_id,
                                      reflectance=reflectance)
 
-    def add_backward_pump(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
+    def add_backward_pump(self, wl: float, input_power: float, wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
                           reflection_target_id=None, reflectance=0.0):
         """
         Adds a new backward propagating single-frequency pump to the simulation.
@@ -162,12 +168,14 @@ class SteadyStateSimulation:
 
         """
 
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='pump',
                                      direction=-1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,

--- a/pyfiberamp/steady_state/steady_state_simulation_with_raman.py
+++ b/pyfiberamp/steady_state/steady_state_simulation_with_raman.py
@@ -17,7 +17,7 @@ class SteadyStateSimulationWithRaman(SteadyStateSimulation):
         self.model = GilesModelWithRaman
 
     def add_pulsed_forward_signal(self, wl, input_power, f_rep, fwhm_duration,
-                                  wl_bandwidth=0.0, loss=None, mode=None, channel_id=None,
+                                  wl_bandwidth=0.0, loss=None, mode=None, overlap=None, channel_id=None,
                                   reflection_target_id=None, reflectance=0.0):
         """Adds a new forward propagating single-frequency pulsed signal to the simulation. A pulsed signal has a higher
         peak input_power resulting in stronger nonlinear effects, in particular spontaneous and stimulated Raman scattering.
@@ -43,12 +43,14 @@ class SteadyStateSimulationWithRaman(SteadyStateSimulation):
 
         """
         check_signal_reprate(f_rep)
+        overlaps = None if overlap is None else np.array(overlap, ndmin=1)
         self.channels.create_channel(channel_type='signal',
                                      direction=1,
                                      fiber=self.fiber,
                                      input_power=input_power,
                                      wl=wl,
                                      mode=mode,
+                                     overlaps=overlaps,
                                      channel_id=channel_id,
                                      wl_bandwidth=wl_bandwidth,
                                      loss=loss,

--- a/tests/test_mode_area_overlap.py
+++ b/tests/test_mode_area_overlap.py
@@ -1,0 +1,39 @@
+import unittest
+import numpy as np
+from pyfiberamp.fibers.passive_fiber import PassiveFiber
+from pyfiberamp.fibers.active_fiber import ActiveFiber
+from pyfiberamp.channels import Channels
+from pyfiberamp.spectroscopies.spectroscopy import Spectroscopy
+from pyfiberamp.helper_funcs import wl_to_freq
+
+class ModeAreaOverlapTestCase(unittest.TestCase):
+    def test_core_area_override(self):
+        mode_area = 50e-12
+        fiber = PassiveFiber(length=1, mode_area=mode_area)
+        self.assertAlmostEqual(fiber.core_area(), mode_area)
+
+    def test_channel_from_overlaps(self):
+        mode_area = 30e-12
+        core_radius = np.sqrt(mode_area/np.pi)
+        absorption = np.array([[1e-6, 1e-24], [1.1e-6, 1e-24]])
+        emission = np.array([[1e-6, 2e-24], [1.1e-6, 2e-24]])
+        spec = Spectroscopy(absorption, emission, 1e-3, 'linear')
+        ion_density = 1e25
+        fiber = ActiveFiber(length=1, core_radius=core_radius, spectroscopy=spec,
+                            ion_number_density=ion_density, mode_area=mode_area)
+        channels = Channels(fiber)
+        overlap = 0.5
+        wl = 1.05e-6
+        channels.create_channel('signal', 1, fiber, input_power=1.0, wl=wl,
+                                 overlaps=np.array([overlap]))
+        ch = channels.forward_signals[0]
+        freq = wl_to_freq(wl)
+        gcs = spec.gain_cs_interp(freq)
+        acs = spec.absorption_cs_interp(freq)
+        expected_gain = overlap * gcs * ion_density
+        expected_abs = overlap * acs * ion_density
+        self.assertAlmostEqual(ch.gain[0], expected_gain)
+        self.assertAlmostEqual(ch.absorption[0], expected_abs)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying effective mode area in FiberBase and derived fibers
- support user-supplied overlaps for channel creation and simulations
- add example script for waveguide simulation without a mode solver

## Testing
- `python examples/waveguide_simulation.py`
- `pytest tests/test_mode_area_overlap.py tests/test_doping_profile.py tests/test_sliced_array.py tests/test_channel_loss.py tests/test_high_power_amplifier.py tests/test_dynamic_simulation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3173b33a4832a957cdd23a07367db