### PR TITLE
Add cluster fraction handling to ActiveFiber

### DIFF
--- a/pyfiberamp/fibers/active_fiber.py
+++ b/pyfiberamp/fibers/active_fiber.py
@@ -11,7 +11,7 @@ class ActiveFiber(FiberBase):
     @classmethod
     def from_cross_section_files(cls, length, absorption_cs_file=None, emission_cs_file=None,
                      core_radius=0, upper_state_lifetime=0, ion_number_density=0,
-                     background_loss=0, core_na=0, mode_area=None):
+                     background_loss=0, core_na=0, mode_area=None, cluster_fraction=0.0):
         """
         :param length: Fiber length
         :type length: float
@@ -29,12 +29,15 @@ class ActiveFiber(FiberBase):
         :type background_loss: float
         :param core_na: Numerical aperture of the core
         :type core_na: float
+        :param cluster_fraction: Fraction of dopant ions forming inactive clusters
+        :type cluster_fraction: float
         """
         spectroscopy = Spectroscopy.from_files(absorption_cs_file, emission_cs_file, upper_state_lifetime)
-        return cls(length, core_radius, background_loss, core_na, spectroscopy, ion_number_density, mode_area)
+        return cls(length, core_radius, background_loss, core_na, spectroscopy,
+                   ion_number_density, mode_area, cluster_fraction)
 
     def __init__(self, length=0, core_radius=0, background_loss=0, core_na=0,
-                 spectroscopy=None, ion_number_density=0, mode_area=None):
+                 spectroscopy=None, ion_number_density=0, mode_area=None, cluster_fraction=0.0):
         """
         :param length: Fiber length
         :type length: float
@@ -48,6 +51,8 @@ class ActiveFiber(FiberBase):
         :type spectroscopy: :class:`~pyfiberamp.spectroscopies.Spectroscopy`
         :param ion_number_density: Number density of the dopant ions (1/m^3)
         :type ion_number_density: float
+        :param cluster_fraction: Fraction of dopant ions forming inactive clusters
+        :type cluster_fraction: float
 
         """
         super().__init__(length=length,
@@ -57,30 +62,55 @@ class ActiveFiber(FiberBase):
                          mode_area=mode_area)
 
         self.spectroscopy = spectroscopy
-        self.doping_profile = DopingProfile(ion_number_densities=[ion_number_density], radii=[core_radius],
-                                            num_of_angular_sections=1, core_radius=core_radius)
+        self.cluster_fraction = cluster_fraction
+        self.doping_profile = DopingProfile(
+            ion_number_densities=[ion_number_density],
+            radii=[core_radius],
+            num_of_angular_sections=1,
+            core_radius=core_radius,
+        )
 
     def set_doping_profile(self, ion_number_densities, radii=None, num_angular_sections=1):
         if radii is None:
             radii = [self.core_radius]
-        self.doping_profile = DopingProfile(ion_number_densities, radii, num_angular_sections, self.core_radius)
+        self.doping_profile = DopingProfile(
+            ion_number_densities, radii, num_angular_sections, self.core_radius
+        )
 
     def set_ion_number_density_based_on_core_absorption(self, wl: float, absorption: float):
         cross_section = self.get_channel_absorption_cross_section(wl_to_freq(wl), 0.0)
         core_mode = self.default_signal_mode(wl_to_freq(wl))
         overlap = core_mode.core_overlap
-        ion_number_density = decibel_to_exp(absorption) / (overlap * cross_section)
-        self.doping_profile.ion_number_densities = np.full_like(self.doping_profile.ion_number_densities,
-                                                                ion_number_density)
+        total_ion_number_density = decibel_to_exp(absorption) / (overlap * cross_section)
+        self.doping_profile.ion_number_densities = np.full_like(
+            self.doping_profile.ion_number_densities,
+            total_ion_number_density,
+        )
 
     @property
     def ion_number_density(self):
         assert len(self.doping_profile.ion_number_densities) == 1
         return self.doping_profile.ion_number_densities[0]
 
+    @property
+    def active_ion_number_density(self):
+        assert len(self.doping_profile.ion_number_densities) == 1
+        return self.ion_number_density * (1 - self.cluster_fraction)
+
+    @property
+    def cluster_ion_density(self):
+        assert len(self.doping_profile.ion_number_densities) == 1
+        return self.ion_number_density * self.cluster_fraction
+
     def saturation_parameter(self):
-        """Returns the constant saturation parameter zeta defined in the Giles model."""
-        return zeta_from_fiber_parameters(self.core_area(), self.spectroscopy.upper_state_lifetime, self.ion_number_density)
+        """Returns the constant saturation parameter zeta defined in the Giles model.
+
+        Only the active dopant ion density contributes to saturation."""
+        return zeta_from_fiber_parameters(
+            self.core_area(),
+            self.spectroscopy.upper_state_lifetime,
+            self.active_ion_number_density,
+        )
 
     def get_channel_emission_cross_section(self, freq, frequency_bandwidth):
         if frequency_bandwidth == 0:


### PR DESCRIPTION
## Summary
- support clustered dopants by adding `cluster_fraction` parameter
- base doping profile on total ion density and derive active/clustered populations for physics
- derive total ion density from absorption, accounting for clustered ions

## Testing
- `pytest tests/test_doping_profile.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b842de13b0832abc38ddf59cc1b1d2